### PR TITLE
parameter nullable in getNameByLocale [A. 2755]

### DIFF
--- a/SportTrackingData/Entity/Sport.php
+++ b/SportTrackingData/Entity/Sport.php
@@ -178,7 +178,7 @@ class Sport extends ProxyObject
      */
     public $userEquipments;
 
-    public function getNameByLocale(string $locale): ?string
+    public function getNameByLocale(?string $locale = 'fr'): ?string
     {
         return $this->getTranslatedPropertyByLocale('translatedNames', $locale);
     }


### PR DESCRIPTION
On a des erreurs de twig dans my2 (lorsque la locale est null).

https://app.assembla.com/spaces/mygeonaute2/tickets/realtime_cardwall?ticket=2755

rendre nullable le paramètre peut empêcher de lever les 500.